### PR TITLE
test(flaky): fix paramter type assert in testBothAnnotatedConstructor test case

### DIFF
--- a/incubator/cdi-inject-weld/src/test/java/org/glassfish/jersey/inject/weld/internal/injector/CachedConstructorAnalyzerTest.java
+++ b/incubator/cdi-inject-weld/src/test/java/org/glassfish/jersey/inject/weld/internal/injector/CachedConstructorAnalyzerTest.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Context;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link CachedConstructorAnalyzer}.
@@ -110,7 +111,8 @@ public class CachedConstructorAnalyzerTest {
 
         Constructor<BothAnnotatedConstructor> constructor = analyzer.getConstructor();
         assertEquals(1, constructor.getParameterCount());
-        assertEquals(Integer.class, constructor.getParameterTypes()[0]);
+        Class<?> parameterType = constructor.getParameterTypes()[0];
+        assertTrue(parameterType.equals(Integer.class) || parameterType.equals(String.class));
     }
 
     @Test


### PR DESCRIPTION
### Description

The `testBothAnnotatedConstructor` test in `CachedConstructorAnalyzerTest` fails randomly because constructor selection is non-deterministic when multiple constructors have the same number of parameters. Specifically, `BothAnnotatedConstructor` has two single-parameter constructors: one accepting a String and the other an Integer. Since `getDeclaredConstructors` does not guarantee order, the test may select either constructor, leading to intermittent failures.

### Fix

Adjust the test to validate that the parameter type of the returned constructor is either `String` or `Integer`, accommodating both possible outcomes.

### How Has This Been Tested

Identified this test to be flaky using [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool (which explores different behaviors of under-determined APIs and reports test failures). Here are the commands to run this test case with NonDex tool

```
# Install the dependencies
mvn install -pl incubator/cdi-inject-weld -am -DskipTests

# Run the test with NonDex
mvn -pl incubator/cdi-inject-weld \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.glassfish.jersey.inject.weld.internal.injector.CachedConstructorAnalyzerTest#testBothAnnotatedConstructor
```
Here is the screenshot of the output generated by the NonDex tool 
<img width="1268" alt="Screenshot 2024-09-02 at 12 05 07 PM" src="https://github.com/user-attachments/assets/a62c55be-b5a9-4297-bbf7-edb8845469bc">

In the above case, we can see that the test case fails intermittently, in the first instance it passed successfully, however in the second instance it failed with error `CachedConstructorAnalyzerTest.testBothAnnotatedConstructor:113 expected: <java.lang.Integer> but was: <java.lang.String>`